### PR TITLE
Fix heading for CVE-2022-46176 patches

### DIFF
--- a/patches/CVE-2022-46176/README.md
+++ b/patches/CVE-2022-46176/README.md
@@ -1,4 +1,4 @@
-# Patches for CVE-2022-36114
+# Patches for CVE-2022-46176
 
 This directory contains the patches for [CVE-2022-46176][cve], to be applied on
 top of a Rust 1.66.0 source tarball.


### PR DESCRIPTION
Fix the heading of the CVE-2022-46176 patches' README, which has the wrong CVE number.